### PR TITLE
continuous_old_action_unembeds set to discrete_old_action_unembeds

### DIFF
--- a/dreamer4/trainers.py
+++ b/dreamer4/trainers.py
@@ -420,7 +420,7 @@ class SimTrainer(Module):
         continuous_log_probs = default(continuous_log_probs, empty_tensor)
 
         discrete_old_action_unembeds = default(discrete_old_action_unembeds, empty_tensor)
-        continuous_old_action_unembeds = default(discrete_old_action_unembeds, empty_tensor)
+        continuous_old_action_unembeds = default(continuous_old_action_unembeds, empty_tensor)
 
         # create the dataset and dataloader
 


### PR DESCRIPTION
 `continuous_old_action_unembeds` was set to `discrete_old_action_unembeds`, leading to later shape issues with kl_div, where kl_div_inputs and kl_div_targets were not the shape shape.