### PR TITLE
fix: guard WM action loss on non-zero weight and use correct parameter() method

### DIFF
--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -4710,7 +4710,10 @@ class DynamicsWorldModel(Module):
         discrete_action_loss = self.zero
         continuous_action_loss = self.zero
 
+        has_action_loss_weight = (self.discrete_action_loss_weight.sum() + self.continuous_action_loss_weight.sum()) > 0
+
         if (
+            has_action_loss_weight and
             self.num_agents == 1 and
             add_autoregressive_action_loss and
             time > 1 and

--- a/dreamer4/trainers.py
+++ b/dreamer4/trainers.py
@@ -483,7 +483,7 @@ class BehaviorCloneTrainer(Module):
             weight_decay = weight_decay
         )
 
-        model_params = list(model.parameters())
+        model_params = list(model.parameter())
         muon_params = list(model.muon_parameters()) if hasattr(model, 'muon_parameters') else []
 
         if exists(self.self_flow_module):

--- a/dreamer4/trainers.py
+++ b/dreamer4/trainers.py
@@ -791,7 +791,7 @@ class BehaviorCloneTrainer(Module):
                 total_continuous_action_loss += (losses.continuous_actions.sum().item() / self.grad_accum_every)
 
             if exists(self.max_grad_norm):
-                self.accelerator.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
+                self.accelerator.clip_grad_norm_(self.model.parameter(), self.max_grad_norm)
 
             self.optim.step()
             self.optim.zero_grad()


### PR DESCRIPTION
Guard action loss computation behind a check that loss weights are non-zero, and fix `parameters()` → `parameter()` calls in BehaviorCloneTrainer.