### PR TITLE
feat: use squared relu activations

### DIFF
--- a/dreamer4/__init__.py
+++ b/dreamer4/__init__.py
@@ -1,7 +1,9 @@
 from dreamer4.dreamer4 import (
     VideoTokenizer,
     DynamicsWorldModel,
-    AxialSpaceTimeTransformer
+    AxialSpaceTimeTransformer,
+    ReLUSquared,
+    relu_squared
 )
 
 

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -79,6 +79,15 @@ from einx import add, multiply, equal, logical_and
 from einops import einsum, rearrange, repeat, reduce, pack, unpack
 from einops.layers.torch import Rearrange, Reduce
 
+# activations
+
+def relu_squared(t):
+    return F.relu(t).square()
+
+class ReLUSquared(Module):
+    def forward(self, x):
+        return relu_squared(x)
+
 # flex attention - but will make sure it works if it is not available
 # may also end up crafting own custom flash attention kernel for this work
 
@@ -509,7 +518,7 @@ class LatentAutoregressiveLoss(Module):
             net = nn.Sequential(
                 project_in,
                 norm,
-                MLP(dim, dim * 4, dim, activation = nn.SiLU())
+                MLP(dim, dim * 4, dim, activation = ReLUSquared())
             )
 
         self.net = net
@@ -1685,7 +1694,7 @@ class Attention(Module):
 
 # feedforward
 
-class SwiGLUFeedforward(Module):
+class ReLUSquaredFeedforward(Module):
     def __init__(
         self,
         dim,
@@ -1695,9 +1704,9 @@ class SwiGLUFeedforward(Module):
         super().__init__()
         self.norm = RMSNorm(dim) if pre_rmsnorm else Identity()
 
-        dim_inner = int(dim * expansion_factor * 2 / 3)
+        dim_inner = int(dim * expansion_factor)
 
-        self.proj_in = Linear(dim, dim_inner * 2)
+        self.proj_in = Linear(dim, dim_inner)
         self.proj_out = Linear(dim_inner, dim)
 
     def muon_parameters(self):
@@ -1709,8 +1718,8 @@ class SwiGLUFeedforward(Module):
     def forward(self, x):
         x = self.norm(x)
 
-        x, gates = self.proj_in(x).chunk(2, dim = -1)
-        x = x * F.gelu(gates)
+        x = self.proj_in(x)
+        x = relu_squared(x)
 
         return self.proj_out(x)
 
@@ -1838,7 +1847,7 @@ class LAPO(Module):
         # state + next state projected embeddings -> latent action - IDM
 
         self.state_norm = RMSNorm(dim_embed)
-        self.to_latent_action_embed = MLP(dim_embed * 2, dim_mlp_hidden, dim_latent_action, activation = nn.SiLU())
+        self.to_latent_action_embed = MLP(dim_embed * 2, dim_mlp_hidden, dim_latent_action, activation = ReLUSquared())
 
         # simplicial embed for action bottleneck
 
@@ -1853,7 +1862,7 @@ class LAPO(Module):
         # forward dynamics model - projected space
 
         self.use_fdm = use_fdm
-        self.to_pred_next_state_embed = MLP(dim_embed + dim_latent_action, dim_mlp_hidden, dim_project, activation = nn.SiLU()) if use_fdm else None
+        self.to_pred_next_state_embed = MLP(dim_embed + dim_latent_action, dim_mlp_hidden, dim_project, activation = ReLUSquared()) if use_fdm else None
 
         # forward dynamics model - raw latent space
 
@@ -1862,7 +1871,7 @@ class LAPO(Module):
 
         if self.has_raw_latent_fdm:
             dim_raw_latent_concat = dim_raw_latent * num_raw_latent_tokens
-            self.to_pred_raw_latent = MLP(dim_embed + dim_latent_action, dim_mlp_hidden, dim_mlp_hidden, dim_raw_latent_concat, activation = nn.SiLU())
+            self.to_pred_raw_latent = MLP(dim_embed + dim_latent_action, dim_mlp_hidden, dim_mlp_hidden, dim_raw_latent_concat, activation = ReLUSquared())
             self.num_raw_latent_tokens = num_raw_latent_tokens
             self.dim_raw_latent = dim_raw_latent
 
@@ -1956,7 +1965,7 @@ class TEM(Module):
             dim_raw_latent,
             dim_structure,
             dim_encoded_sensory,
-            activation = nn.SiLU()
+            activation = ReLUSquared()
         )
 
         self.structural_norm = RMSNorm(dim_structure)
@@ -1987,7 +1996,7 @@ class TEM(Module):
         if talking_heads:
             nn.init.dirac_(self.talking_heads.weight)
 
-        self.activation = nn.SiLU()
+        self.activation = ReLUSquared()
 
         # dummy tokens for shifted attention to mask diagonal
 
@@ -2011,7 +2020,7 @@ class TEM(Module):
             dim_structure,
             dim_structure,
             dim_raw_latent * num_raw_latent_tokens,
-            activation = nn.SiLU()
+            activation = ReLUSquared()
         )
 
         self.register_buffer('zero', tensor(0.), persistent = False)
@@ -2195,7 +2204,7 @@ class AxialSpaceTimeTransformer(Module):
                 rearrange_to_attend,
                 rearrange_from_attend,
                 Residual(Attention(dim = dim, heads = attn_heads, dim_head = attn_dim_head, value_residual = value_residual, **attn_kwargs)),
-                Residual(SwiGLUFeedforward(dim = dim, **ff_kwargs))
+                Residual(ReLUSquaredFeedforward(dim = dim, **ff_kwargs))
             ]))
 
             rnn_layers.append(Residual(GRULayer(dim, dim)) if is_time_block and rnn_time else None)
@@ -2232,13 +2241,13 @@ class AxialSpaceTimeTransformer(Module):
 
         if self.should_special_cross_attend:
             self.final_special_cross_attn = Residual(Attention(dim = dim, heads = attn_heads, dim_head = attn_dim_head, pre_context_rmsnorm = True, **attn_kwargs))
-            self.final_special_ff = Residual(SwiGLUFeedforward(dim = dim, **ff_kwargs))
+            self.final_special_ff = Residual(ReLUSquaredFeedforward(dim = dim, **ff_kwargs))
 
     def muon_parameters(self):
         muon_params = []
 
         for m in self.modules():
-            if isinstance(m, (Attention, SwiGLUFeedforward)):
+            if isinstance(m, (Attention, ReLUSquaredFeedforward)):
                 muon_params.extend(m.muon_parameters())
 
         return muon_params
@@ -2469,7 +2478,7 @@ class CausalDepthwiseConv3d(Module):
             groups = dim
         )
 
-        self.act = nn.SiLU()
+        self.act = ReLUSquared()
         self.proj = Linear(dim, dim)
 
     def forward(
@@ -2724,6 +2733,7 @@ class VideoTokenizer(Module):
             dim = dim * 2,
             dim_out = dim,
             depth = decoder_pos_mlp_depth,
+            activation = ReLUSquared()
         )
 
         # decoder transformer
@@ -3183,7 +3193,7 @@ class SelfFlow(Module):
 
         self.teacher_time_modifier_fn = teacher_time_modifier_fn
 
-        self.student_predict_head = SwiGLUFeedforward(dim = model.dim)
+        self.student_predict_head = ReLUSquaredFeedforward(dim = model.dim)
 
     def forward(
         self,
@@ -3477,7 +3487,8 @@ class DynamicsWorldModel(Module):
             dim_in = dim,
             dim = dim * 4,
             dim_out = dim * 4,
-            depth = policy_head_mlp_depth
+            depth = policy_head_mlp_depth,
+            activation = ReLUSquared()
         )
 
         # action embedder
@@ -3537,7 +3548,8 @@ class DynamicsWorldModel(Module):
                     dim_in = dim_agent_state_in,
                     dim = dim_agent_state_in * 2,
                     dim_out = num_latent_tokens * dim_latent * 2,
-                    depth = 2
+                    depth = 2,
+                    activation = ReLUSquared()
                 ),
                 Rearrange('... (n d two) -> ... n d two', n = num_latent_tokens, two = 2)
             )
@@ -3574,6 +3586,9 @@ class DynamicsWorldModel(Module):
         self.predict_terminals = predict_terminals
 
         if predict_terminals:
+            predict_terminal_mlp_kwargs = dict(predict_terminal_mlp_kwargs)
+            predict_terminal_mlp_kwargs['activation'] = ReLUSquared()
+
             self.to_state_terminal_pred = Sequential(
                 create_mlp(
                     dim_in = dim_latent,
@@ -3591,6 +3606,7 @@ class DynamicsWorldModel(Module):
             dim = dim * 4,
             dim_out = self.reward_encoder.num_bins,
             depth = value_head_mlp_depth,
+            activation = ReLUSquared()
         )
 
         # pre encoder and ssl modules

--- a/train_cartpole_with_dynamics_rl.py
+++ b/train_cartpole_with_dynamics_rl.py
@@ -54,7 +54,8 @@ from dreamer4.dreamer4 import (
     exists,
     default,
     cast_to_tensor,
-    VideoTokenizer
+    VideoTokenizer,
+    ReLUSquared
 )
 
 # env
@@ -108,11 +109,11 @@ class SmallConvEncoder(nn.Module):
 
         self.net = nn.Sequential(
             nn.Conv2d(3, 16, 4, stride = 2, padding = 1),
-            nn.ReLU(),
+            ReLUSquared(),
             nn.Conv2d(16, 32, 4, stride = 2, padding = 1),
-            nn.ReLU(),
+            ReLUSquared(),
             nn.Conv2d(32, 64, 4, stride = 2, padding = 1),
-            nn.ReLU(),
+            ReLUSquared(),
             nn.Conv2d(64, num_latent_tokens * dim_latent, 8, stride = 1, padding = 0),
             nn.Tanh()
         )


### PR DESCRIPTION
Drawing on Primer (https://arxiv.org/pdf/2109.08668) and my local tests where relusq outperforms ReLU and GEGLU/SwiGLU in returns, while avoiding GLU overhead.

## Summary
- replace hidden MLP/head activations with squared ReLU
- switch transformer feedforwards to plain squared-ReLU FFNs, removing GLU-style gating
- export the reusable ReLUSquared activation

## Tests passed
- python -m compileall dreamer4 train_cartpole_with_dynamics_rl.py
- pytest -q tests/test_dreamer.py::test_action_embedder tests/test_dreamer.py::test_mtp tests/test_dreamer.py::test_action_with_world_model
- relusq smoke checks for feedforward, transformer forward, policy/value heads