### PR TITLE
fix: disable agent state prediction by default

### DIFF
--- a/train_cartpole_with_dynamics_rl.py
+++ b/train_cartpole_with_dynamics_rl.py
@@ -157,7 +157,7 @@ class TransformerPPOAgent(nn.Module):
         critic_depth = 0,
         spatial_pre_encoder_depth = 0,
         action_pre_encoder_depth = 0,
-        agent_predicts_latent = True,
+        agent_predicts_latent = False,
         ssl_lapo = False,
         ssl_lapo_use_fdm = True,
         ssl_lapo_pred_actions = True,


### PR DESCRIPTION
## Summary
- Default the CartPole dynamics trainer wrapper to not enable agent state prediction

- stabalized grads signifcantly (blue with disabled, green with enabled, otherwise default hyperparams)

<img width="567" height="658" alt="Screenshot from 2026-05-07 18-54-53" src="https://github.com/user-attachments/assets/7509a0ec-6824-4c8d-973a-0fa62337f2e2" />
<img width="573" height="659" alt="Screenshot from 2026-05-07 18-54-26" src="https://github.com/user-attachments/assets/af73c436-39f5-4ef5-920b-da597106fddb" />
<img width="578" height="697" alt="Screenshot from 2026-05-07 18-54-21" src="https://github.com/user-attachments/assets/2ac0cc7f-87e9-49f7-9016-96d933a5ea73" />


## Tests
- uv run --with fire --with gymnasium --with numpy --with pygame --with wandb python - <<'PY'
from train_cartpole_with_dynamics_rl import TransformerPPOAgent
agent = TransformerPPOAgent()
assert agent.dynamics.agent_predicts_state is False
print('agent_predicts_state', agent.dynamics.agent_predicts_state)
PY